### PR TITLE
Axis classes to allow independent X/Y axis styling

### DIFF
--- a/lib/lineChart.js
+++ b/lib/lineChart.js
@@ -89,12 +89,12 @@ var _create =  function(data, opts){
         .orient('left');
 
   _state.vis.append('svg:g')
-    .attr('class', 'axis')
+    .attr('class', 'axis axis--x')
     .attr('transform', 'translate(0,' + (_state.height - _state.padding.bottom) + ')')
     .call(xAxis);
 
   _state.vis.append('svg:g')
-    .attr('class', 'axis')
+    .attr('class', 'axis axis--y')
     .attr('transform', 'translate(' + (_state.padding.left) + ',0)')
     .call(yAxis);
 


### PR DESCRIPTION
Separated from Pull #7. Adds some CSS classes to allow independent X(location)/Y(specificity) axis styling.

Also move the axis labels outward slightly so they don't overlap with the ticks.
